### PR TITLE
User roles invitation

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,10 +4,12 @@ import sys
 import argparse
 from dotenv import load_dotenv
 from rich.progress import track
+from rich.console import Console
 from rich import print as cprint
 from utils import github
 
 gh: github
+console = Console()
 
 
 def multi_invite(org: str, users_file: str):
@@ -32,7 +34,8 @@ def multi_invite(org: str, users_file: str):
 
     # Invite users with roles
     cprint(f"[magenta]  Inviting {len(users_with_roles)} user/s ..")
-    for idx, user_role_tuple in enumerate(users_with_roles):
+
+    for idx, user_role_tuple in track(enumerate(users_with_roles), total=len(users_with_roles), description="Inviting users"):
         if len(user_role_tuple) != 2:
             cprint(f"[yellow]: Invalid format in line {idx + 1}. Skipping.")
             continue


### PR DESCRIPTION
**Description:**
Support to set role for each user #1

Changes Made:

- Added support to invite users to a GitHub organization with specified roles.
- Introduced a new feature to read a file containing usernames and roles.
- Implemented input validation to ensure the correct format.
- Enhanced the `multi_invite` function in main.py to gracefully handle existing users.

This addresses issue #1.